### PR TITLE
sada's LTO

### DIFF
--- a/mjit_compile.c
+++ b/mjit_compile.c
@@ -20,6 +20,7 @@
 #include "insns.inc"
 #include "insns_info.inc"
 #include "vm_insnhelper.h"
+#include <dlfcn.h>
 
 // Macros to check if a position is already compiled using compile_status.stack_size_for_pos
 #define NOT_COMPILED_STACK_SIZE -1

--- a/mjit_worker.c
+++ b/mjit_worker.c
@@ -671,7 +671,7 @@ static bool
 compile_c_to_so(const char *c_file, const char *so_file)
 {
     int exit_code;
-    const char *files[] = { NULL, NULL, NULL, NULL, NULL, NULL, "-link", libruby_pathflag, NULL };
+    const char *files[] = { NULL, NULL, NULL, NULL, NULL, NULL, "-link", libruby_pathflag, "-flto", NULL };
     char **args;
     char *p, *obj_file;
 
@@ -753,6 +753,7 @@ make_pch(void)
         // -nodefaultlibs is a linker flag, but it may affect cc1 behavior on Gentoo, which should NOT be changed on pch:
         // https://gitweb.gentoo.org/proj/gcc-patches.git/tree/7.3.0/gentoo/13_all_default-ssp-fix.patch
         GCC_NOSTDLIB_FLAGS
+        "-flto",
         "-o", NULL, NULL,
         NULL,
     };
@@ -797,7 +798,7 @@ compile_c_to_o(const char *c_file, const char *o_file)
 # ifdef __clang__
         "-include-pch", NULL,
 # endif
-        "-c", NULL
+        "-c", "-flto", NULL
     };
     char **args;
 
@@ -828,7 +829,7 @@ link_o_to_so(const char **o_files, const char *so_file)
 # ifdef _WIN32
         libruby_pathflag,
 # endif
-        NULL
+        "-flto", NULL
     };
     char **args;
 

--- a/tool/ruby_vm/views/_mjit_compile_insn.erb
+++ b/tool/ruby_vm/views/_mjit_compile_insn.erb
@@ -51,7 +51,28 @@
 <%= render 'mjit_compile_pc_and_sp', locals: { insn: insn } -%>
 %
 % # JIT: Print insn body in insns.def
+% if insn.name == 'send'
+      Dl_info in;
+      if (dladdr(((CALL_CACHE)operands[1])->call, &in) != 0) {
+        fprintf(f, "    {\n");
+        fprintf(f, "        struct rb_calling_info calling;\n\n");
+        fprintf(f, "        calling.block_handler = vm_caller_setup_arg_block(ec, reg_cfp, ci, blockiseq, FALSE);\n");
+        fprintf(f, "        calling.recv = TOPN(calling.argc = ci->orig_argc);\n");
+        fprintf(f, "        vm_search_method(ci, cc, calling.recv);\n");
+        fprintf(f, "        VALUE v = %s(ec, GET_CFP(), &calling, ci, cc);\n", in.dli_sname);
+        fprintf(f, "        if (v == Qundef) {\n");
+        fprintf(f, "            EXEC_EC_CFP(val);\n");
+        fprintf(f, "        } else {\n");
+        fprintf(f, "            val = v;\n");
+        fprintf(f, "        }\n");
+        fprintf(f, "    }\n");
+      }
+      else {
+% end
 <%= render 'mjit_compile_insn_body', locals: { insn: insn } -%>
+% if insn.name == 'send'
+      }
+% end
 %
 % # JIT: Set return values
 % insn.rets.reverse_each.with_index do |ret, i|


### PR DESCRIPTION
patch: https://gist.github.com/frsyuki/ce9d9715309cdd20787026954a6eb31f
benchmark: https://gist.github.com/frsyuki/876350ee8d562e2741e4cf50cc4aeb6c

```bash
../configure --prefix="${HOME}/.rbenv/versions/ruby-lto" \
  --disable-install-doc --enable-shared \
  CFLAGS="$(ruby -e 'puts RbConfig::CONFIG[%q(CFLAGS)]) -flto -fno-stack-protector" \
  LDFLAGS="$(ruby -e 'puts RbConfig::CONFIG[%q(LDFLAGS)]) -flto -fno-stack-protector"
```