### PR TITLE
sada's LTO on 2.6

### DIFF
--- a/mjit_compile.c
+++ b/mjit_compile.c
@@ -20,6 +20,7 @@
 #include "insns.inc"
 #include "insns_info.inc"
 #include "vm_insnhelper.h"
+#include <dlfcn.h>
 
 /* Macros to check if a position is already compiled using compile_status.stack_size_for_pos */
 #define NOT_COMPILED_STACK_SIZE -1

--- a/mjit_worker.c
+++ b/mjit_worker.c
@@ -661,7 +661,7 @@ static int
 compile_c_to_so(const char *c_file, const char *so_file)
 {
     int exit_code;
-    const char *files[] = { NULL, NULL, NULL, NULL, NULL, NULL, "-link", libruby_pathflag, NULL };
+    const char *files[] = { NULL, NULL, NULL, NULL, NULL, NULL, "-link", libruby_pathflag, "-flto", NULL };
     char **args;
     char *p, *obj_file;
 
@@ -743,6 +743,7 @@ make_pch(void)
         // -nodefaultlibs is a linker flag, but it may affect cc1 behavior on Gentoo, which should NOT be changed on pch:
         // https://gitweb.gentoo.org/proj/gcc-patches.git/tree/7.3.0/gentoo/13_all_default-ssp-fix.patch
         GCC_NOSTDLIB_FLAGS
+        "-flto",
         "-o", NULL, NULL,
         NULL,
     };
@@ -787,7 +788,7 @@ compile_c_to_o(const char *c_file, const char *o_file)
 # ifdef __clang__
         "-include-pch", NULL,
 # endif
-        "-c", NULL
+        "-c", "-flto", NULL
     };
     char **args;
 
@@ -818,7 +819,7 @@ link_o_to_so(const char **o_files, const char *so_file)
 # ifdef _WIN32
         libruby_pathflag,
 # endif
-        NULL
+        "-flto", NULL
     };
     char **args;
 

--- a/tool/ruby_vm/views/_mjit_compile_insn.erb
+++ b/tool/ruby_vm/views/_mjit_compile_insn.erb
@@ -51,7 +51,28 @@
 <%= render 'mjit_compile_pc_and_sp', locals: { insn: insn } -%>
 %
 % # JIT: Print insn body in insns.def
+% if insn.name == 'send'
+      Dl_info in;
+      if (dladdr(((CALL_CACHE)operands[1])->call, &in) != 0) {
+        fprintf(f, "    {\n");
+        fprintf(f, "        struct rb_calling_info calling;\n\n");
+        fprintf(f, "        calling.block_handler = vm_caller_setup_arg_block(ec, reg_cfp, ci, blockiseq, FALSE);\n");
+        fprintf(f, "        calling.recv = TOPN(calling.argc = ci->orig_argc);\n");
+        fprintf(f, "        vm_search_method(ci, cc, calling.recv);\n");
+        fprintf(f, "        VALUE v = %s(ec, GET_CFP(), &calling, ci, cc);\n", in.dli_sname);
+        fprintf(f, "        if (v == Qundef) {\n");
+        fprintf(f, "            EXEC_EC_CFP(val);\n");
+        fprintf(f, "        } else {\n");
+        fprintf(f, "            val = v;\n");
+        fprintf(f, "        }\n");
+        fprintf(f, "    }\n");
+      }
+      else {
+% end
 <%= render 'mjit_compile_insn_body', locals: { insn: insn } -%>
+% if insn.name == 'send'
+      }
+% end
 %
 % # JIT: Set return values
 % insn.rets.reverse_each.with_index do |ret, i|


### PR DESCRIPTION
base: https://github.com/k0kubun/ruby/tree/ruby_2_6 (dropping stack protector for lto https://github.com/k0kubun/ruby/commit/583caaf8bb5b267d9f6a5ebf8715d108adcfe34a)

patch: https://gist.github.com/frsyuki/ce9d9715309cdd20787026954a6eb31f
benchmark: https://gist.github.com/frsyuki/876350ee8d562e2741e4cf50cc4aeb6c

## How I built Ruby
Dropping stack protector https://github.com/k0kubun/ruby/commit/583caaf8bb5b267d9f6a5ebf8715d108adcfe34a in both branches.

### `ruby26`: k0kubun/ruby [ruby_2_6 branch](https://github.com/k0kubun/ruby/tree/ruby_2_6)

```bash
../configure --prefix="${HOME}/.rbenv/versions/ruby26" \
  --disable-install-doc --enable-shared
```

### `ruby26-lto`: This branch (almost sada's original patch)
```bash
../configure --prefix="${HOME}/.rbenv/versions/ruby26-lto" \
  --disable-install-doc --enable-shared \
  CFLAGS="$(~/.rbenv/versions/ruby26/bin/ruby -e 'puts RbConfig::CONFIG[%q(CFLAGS)]') -flto=thin" \
  LDFLAGS="$(~/.rbenv/versions/ruby26/bin/ruby -e 'puts RbConfig::CONFIG[%q(LDFLAGS)]') -flto=thin"
```

### `ruby26-inlinecfunc`: k0kubun/ruby [ruby_2_6-inlinecfunc](https://github.com/k0kubun/ruby/tree/ruby_2_6-inlinecfunc) branch

```bash
../configure --prefix="${HOME}/.rbenv/versions/ruby26-inlinecfunc" \
  --disable-install-doc --enable-shared
```

### `ruby26-inlinecfunc-lto`: k0kubun/ruby [ruby_2_6-inlinecfunc-lto](https://github.com/k0kubun/ruby/tree/ruby_2_6-inlinecfunc-lto) branch

```bash
../configure --prefix="${HOME}/.rbenv/versions/ruby26-inlinecfunc-lto" \
  --disable-install-doc --enable-shared \
  CFLAGS="$(~/.rbenv/versions/ruby26-inlinecfunc/bin/ruby -e 'puts RbConfig::CONFIG[%q(CFLAGS)]') -flto=thin" \
  LDFLAGS="$(~/.rbenv/versions/ruby26-inlinecfunc/bin/ruby -e 'puts RbConfig::CONFIG[%q(LDFLAGS)]') -flto=thin"
```