### PR TITLE
LLVM-backed MJIT

### DIFF
--- a/mjit.c
+++ b/mjit.c
@@ -708,6 +708,14 @@ mjit_init(struct mjit_options *opts)
     if (mjit_opts.max_cache_size < MIN_CACHE_SIZE)
         mjit_opts.max_cache_size = MIN_CACHE_SIZE;
 
+#if MJIT_LLVM
+    // Required to generate native code.
+    LLVMInitializeNativeTarget();
+    LLVMInitializeNativeAsmPrinter();
+    LLVMInitializeNativeAsmParser();
+    LLVMLinkInMCJIT();
+#endif
+
     // Initialize variables for compilation
 #ifdef _MSC_VER
     pch_status = PCH_SUCCESS; // has prebuilt precompiled header


### PR DESCRIPTION
Just an experiment.
 
<hr>

ISeq → C → LLVM IR → LLVM Bitcode → Native code

```bash
$ ruby --jit-verbose=2 ~/tmp/a.rb
MJIT: CC defaults to /usr/bin/clang-3.9
MJIT: tmp_dir is /tmp
Creating precompiled header
Starting process: /usr/bin/clang-3.9 /usr/bin/clang-3.9 -w -Wfatal-errors -fPIC -shared -w -pipe -O3 -emit-pch -o /tmp/_ruby_mjit_hp2712u0.h.gch /home/k0kubun/.rbenv/versions/ruby-llvm/include/ruby-2.7.0/x86_64-linux/rb_mjit_min_header-2.7.0.h
start compilation: block in <main>@/home/k0kubun/tmp/a.rb:5 -> /tmp/_ruby_mjit_p2712u0.c
Starting process: /usr/bin/clang-3.9 /usr/bin/clang-3.9 -w -Wfatal-errors -fPIC -shared -w -pipe -O3 -o /tmp/_ruby_mjit_p2712u0.ll /tmp/_ruby_mjit_p2712u0.c -include-pch /tmp/_ruby_mjit_hp2712u0.h.gch -S -emit-llvm -L/usr/lib/llvm-3.9/lib -lLLVM-3.9 -Wl,--compress-debug-sections=zlib
Starting process: /usr/bin/llvm-as /usr/bin/llvm-as -o /tmp/_ruby_mjit_p2712u0.bc /tmp/_ruby_mjit_p2712u0.ll
JIT success (48.7ms): block in <main>@/home/k0kubun/tmp/a.rb:5 -> /tmp/_ruby_mjit_p2712u0.c
start compilation: a@/home/k0kubun/tmp/a.rb:1 -> /tmp/_ruby_mjit_p2712u1.c
Starting process: /usr/bin/clang-3.9 /usr/bin/clang-3.9 -w -Wfatal-errors -fPIC -shared -w -pipe -O3 -o /tmp/_ruby_mjit_p2712u1.ll /tmp/_ruby_mjit_p2712u1.c -include-pch /tmp/_ruby_mjit_hp2712u0.h.gch -S -emit-llvm -L/usr/lib/llvm-3.9/lib -lLLVM-3.9 -Wl,--compress-debug-sections=zlib
Starting process: /usr/bin/llvm-as /usr/bin/llvm-as -o /tmp/_ruby_mjit_p2712u1.bc /tmp/_ruby_mjit_p2712u1.ll
JIT success (47.6ms): a@/home/k0kubun/tmp/a.rb:1 -> /tmp/_ruby_mjit_p2712u1.c
Stopping worker thread
Successful MJIT finish
```